### PR TITLE
Rework grid to avoid override issue

### DIFF
--- a/src/Resources/config/sylius/grid.yaml
+++ b/src/Resources/config/sylius/grid.yaml
@@ -4,7 +4,7 @@ sylius_grid:
             driver:
                 name: doctrine/orm
                 options:
-                    class: MonsieurBiz\SyliusCmsPagePlugin\Entity\Page
+                    class: '%monsieurbiz_cms_page.model.page.class%'
             limits: [25, 50, 100, 200]
             fields:
                 code:


### PR DESCRIPTION
Currently if we override the entity, we will have some weird issues since this grid is looking for the original class, and not the override.

Such as : 
![image](https://user-images.githubusercontent.com/9363039/100840058-99bc3b00-3475-11eb-9278-fb00ed74bb67.png)
