### PR TITLE
Declare migration path using prepend config extension

### DIFF
--- a/src/DependencyInjection/MonsieurBizSyliusCmsPageExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusCmsPageExtension.php
@@ -16,9 +16,10 @@ namespace MonsieurBiz\SyliusCmsPagePlugin\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-final class MonsieurBizSyliusCmsPageExtension extends Extension
+final class MonsieurBizSyliusCmsPageExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -36,5 +37,18 @@ final class MonsieurBizSyliusCmsPageExtension extends Extension
     public function getAlias()
     {
         return str_replace('monsieur_biz', 'monsieurbiz', parent::getAlias());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container): void
+    {
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $container->prependExtensionConfig('doctrine_migrations', [
+            'migrations_paths' => array_merge(array_pop($doctrineConfig)['migrations_paths'] ?? [], [
+                'MonsieurBiz\SyliusCmsPagePlugin\Migrations' => '@MonsieurBizSyliusCmsPagePlugin/Migrations',
+            ]),
+        ]);
     }
 }

--- a/src/Resources/config/app/doctrine_migrations.yaml
+++ b/src/Resources/config/app/doctrine_migrations.yaml
@@ -1,3 +1,0 @@
-doctrine_migrations:
-    migrations_paths:
-        'MonsieurBiz\SyliusCmsPagePlugin\Migrations': "@MonsieurBizSyliusCmsPagePlugin/Migrations"

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: 'app/doctrine_migrations.yaml' }
     - { resource: "sylius/resources.yaml" }
     - { resource: "sylius/grid.yaml" }
     - { resource: "sylius/fixtures.yaml" }


### PR DESCRIPTION
Instead of declaring the migration path into a config file, we use the prepend extension method. that's the way to be sure that the local migration path `config/packages/doctrine_migrations.yaml` stay the default one (first in the list).

See:
- [This Sylius Core file](https://github.com/Sylius/Sylius/blob/db8eb7568bc897b2978fb1c48e081ba960369e3c/src/Sylius/Bundle/CoreBundle/DependencyInjection/PrependDoctrineMigrationsTrait.php#L36)
- [This article](https://www.goetas.com/blog/multi-namespace-migrations-with-doctrinemigrations-30/#extra%3A-auto-registered-migrations)﻿
