### PR TITLE
Ignore the shop route for APIs

### DIFF
--- a/src/Resources/config/routing/shop.yaml
+++ b/src/Resources/config/routing/shop.yaml
@@ -14,4 +14,4 @@ monsieurbiz_cms_page_show:
                     - "expr:service('sylius.context.channel').getChannel().getCode()"
     requirements:
         slug: .+
-    condition: "context.checkPageSlug(request)"
+    condition: "not(context.getPathInfo() matches '`^%sylius.security.new_api_route%`') and context.checkPageSlug(request)"


### PR DESCRIPTION
When we try to use the APIs, and especially GraphQL, we get an interesting error:

```
{
  "errors": [
    {
      "debugMessage": "Call to undefined method Symfony\\Component\\Routing\\RequestContext::checkPageSlug()",
      "message": "Internal server error",
      "extensions": {
        "category": "internal"
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
…
```

This is due to API Platform which uses the original Context, without our decorator.

Adding the condition in the route allows us to ignore the route in case we are calling the API via GraphQL.

With the change, it works! :p 
<img width="891" alt="image" src="https://user-images.githubusercontent.com/858611/157628848-1be7e549-daa3-4a77-8754-11a3bac463f6.png">


closes #28