### PR TITLE
Fixed issue with doctrine migration priority

### DIFF
--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -2,3 +2,7 @@ imports:
     - { resource: "sylius/resources.yaml" }
     - { resource: "sylius/grid.yaml" }
     - { resource: "sylius/fixtures.yaml" }
+
+sylius_labs_doctrine_migrations_extra:
+    migrations:
+        MonsieurBiz\SyliusCmsPagePlugin\Migrations: ~


### PR DESCRIPTION
Fixed issue with doctrine migration priority. Without theses changes SyliusCmsPagePlugin Migrations have the highest priority, and always migrating them last.