### PR TITLE
Avoid channel context error in show button while saving a page with error

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -4,7 +4,7 @@ monsieurbiz_sylius_cms_page_admin:
         alias: monsieurbiz_cms_page.page
         section: admin
         templates: "@SyliusAdmin\\Crud"
-        except: ['show']
+        except: ['show', 'update']
         redirect: update
         grid: monsieurbiz_cms_page
         vars:
@@ -12,7 +12,6 @@ monsieurbiz_sylius_cms_page_admin:
                 subheader: monsieurbiz_cms_page.ui.pages_subheader
                 templates:
                     form: "@MonsieurBizSyliusCmsPagePlugin/Admin/Page/_form.html.twig"
-                    toolbar: "@MonsieurBizSyliusCmsPagePlugin/Admin/Page/Update/_toolbar.html.twig"
             index:
                 icon: 'file alternate'
     type: sylius.resource
@@ -24,3 +23,20 @@ monsieurbiz_sylius_cms_page_ajax_generate_page_slug:
     defaults:
         _controller: MonsieurBiz\SyliusCmsPagePlugin\Controller\Admin\Page\PageSlugController::generateAction
 
+
+monsieurbiz_cms_page_admin_page_update:
+    path: /pages/{id}/edit
+    methods: [GET, PUT, PATCH]
+    defaults:
+        _controller: monsieurbiz_cms_page.controller.page:updateAction
+        _sylius:
+            section: admin
+            permission: true
+            redirect: referer
+            template: "@SyliusAdmin/Crud/update.html.twig"
+            vars:
+                subheader: monsieurbiz_cms_page.ui.pages_subheader
+                icon: file alternate
+                templates:
+                    form: "@MonsieurBizSyliusCmsPagePlugin/Admin/Page/_form.html.twig"
+                    toolbar: "@MonsieurBizSyliusCmsPagePlugin/Admin/Page/Update/_toolbar.html.twig"


### PR DESCRIPTION
Avoid error while saving a page with invalid form.
The `_showInShopButton.html.twig` is loaded in `src/Resources/views/Admin/Page/Update/_toolbar.html.twig`

With this PR the Update toolbar is only loaded in update route.
Sylius does the same in the product admin toolbar.

![image](https://user-images.githubusercontent.com/11380627/213417552-36650abf-6e44-4ada-83a7-a3791ac61998.png)
