### PR TITLE
Call correctly decorated service with splat argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test.twig: ## Validate Twig templates
 ### SYLIUS
 ### ¯¯¯¯¯¯
 
-sylius: dependencies sylius.database sylius.fixtures sylius.assets ## Install Sylius
+sylius: dependencies sylius.database sylius.fixtures sylius.assets messenger.setup ## Install Sylius
 .PHONY: sylius
 
 sylius.database: ## Setup the database
@@ -160,6 +160,9 @@ sylius.assets: ## Install all assets with symlinks
 	${CONSOLE} assets:install --symlink
 	${CONSOLE} sylius:install:assets
 	${CONSOLE} sylius:theme:assets:install --symlink
+
+messenger.setup: ## Setup Messenger transports
+	${CONSOLE} messenger:setup-transports
 
 ###
 ### PLATFORM

--- a/src/Routing/RequestContext.php
+++ b/src/Routing/RequestContext.php
@@ -93,7 +93,7 @@ final class RequestContext extends BaseRequestContext
     {
         $callback = [$this->decorated, $name];
         if (\is_callable($callback)) {
-            return \call_user_func($callback, $arguments);
+            return \call_user_func($callback, ...$arguments);
         }
 
         throw new Exception(sprintf('Method %s not found for class "%s"', $name, \get_class($this->decorated)));


### PR DESCRIPTION
Avoid error like this : 

```
MonsieurBiz\SyliusCmsPagePlugin\Routing\RequestContext::checkPageSlug(): Argument #1 ($request) must be of type Symfony\Component\HttpFoundation\Request, array given, called in /apps/sylius/vendor/monsieurbiz/sylius-no-commerce-plugin/src/Routing/NoCommerceRequestContext.php on line 60
```