### PR TITLE
Allows 2 pages to have the same slug depending on channel and locale

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "symfony/thanks": true,
             "ergebnis/composer-normalize": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "php-http/discovery": true
         }
     }
 }

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusCmsPagePlugin\Repository;
 
 use Doctrine\ORM\NonUniqueResultException;
-use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use MonsieurBiz\SyliusCmsPagePlugin\Entity\PageInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
@@ -31,11 +30,7 @@ class PageRepository extends EntityRepository implements PageRepositoryInterface
         ;
     }
 
-    /**
-     * @throws NoResultException
-     * @throws NonUniqueResultException
-     */
-    public function existsOneByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug): bool
+    public function existsOneEnabledByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug): bool
     {
         $count = (int) $this
             ->createQueryBuilder('p')

--- a/src/Repository/PageRepositoryInterface.php
+++ b/src/Repository/PageRepositoryInterface.php
@@ -22,6 +22,8 @@ interface PageRepositoryInterface extends RepositoryInterface
 {
     public function createListQueryBuilder(string $localeCode): QueryBuilder;
 
+    public function existsOneByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug, array $excludedPages = []): bool;
+
     public function existsOneEnabledByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug): bool;
 
     public function findOneEnabledBySlugAndChannelCode(string $slug, string $localeCode, string $channelCode): ?PageInterface;

--- a/src/Repository/PageRepositoryInterface.php
+++ b/src/Repository/PageRepositoryInterface.php
@@ -22,7 +22,7 @@ interface PageRepositoryInterface extends RepositoryInterface
 {
     public function createListQueryBuilder(string $localeCode): QueryBuilder;
 
-    public function existsOneByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug): bool;
+    public function existsOneEnabledByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug): bool;
 
     public function findOneEnabledBySlugAndChannelCode(string $slug, string $localeCode, string $channelCode): ?PageInterface;
 }

--- a/src/Resources/config/sylius/grid.yaml
+++ b/src/Resources/config/sylius/grid.yaml
@@ -21,6 +21,11 @@ sylius_grid:
                     type: string
                     label: monsieurbiz_cms_page.ui.form.title
                     sortable: translation.title
+                channels:
+                    type: twig
+                    label: sylius.ui.channels
+                    options:
+                        template: '@SyliusAdmin/Grid/Field/_channels.html.twig'
                 enabled:
                     type: twig
                     label: monsieurbiz_cms_page.ui.form.enabled
@@ -56,3 +61,10 @@ sylius_grid:
                     label: monsieurbiz_cms_page.ui.form.content
                     options:
                         fields: [translation.content]
+                channel:
+                    type: entity
+                    label: sylius.ui.channel
+                    options:
+                        fields: [channels.id]
+                    form_options:
+                        class: "%sylius.model.channel.class%"

--- a/src/Resources/config/validation/Page.yaml
+++ b/src/Resources/config/validation/Page.yaml
@@ -3,6 +3,8 @@ MonsieurBiz\SyliusCmsPagePlugin\Entity\Page:
         -   Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
                 fields: [code]
                 groups: [monsieurbiz]
+        -   MonsieurBiz\SyliusCmsPagePlugin\Validator\Constraints\UniqueSlugByChannel:
+                groups: [monsieurbiz]
     properties:
         code:
             -   NotBlank:

--- a/src/Resources/config/validation/PageTranslation.yaml
+++ b/src/Resources/config/validation/PageTranslation.yaml
@@ -1,9 +1,4 @@
 MonsieurBiz\SyliusCmsPagePlugin\Entity\PageTranslation:
-    constraints:
-        -   Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
-                fields: [slug, locale]
-                errorPath: slug
-                groups: [monsieurbiz]
     properties:
         title:
             -   NotBlank:

--- a/src/Resources/translations/validators.en.yaml
+++ b/src/Resources/translations/validators.en.yaml
@@ -1,0 +1,4 @@
+monsieurbiz_cms_page:
+    ui:
+        slug:
+            unique: 'This slug is already used for another page with channel %channel% and locale %locale%.'

--- a/src/Resources/translations/validators.fr.yaml
+++ b/src/Resources/translations/validators.fr.yaml
@@ -1,0 +1,4 @@
+monsieurbiz_cms_page:
+    ui:
+        slug:
+            unique: 'Ce slug est déjà utilisé pour une autre page avec le canal %channel% et la locale %locale%.'

--- a/src/Routing/PageSlugConditionChecker.php
+++ b/src/Routing/PageSlugConditionChecker.php
@@ -51,7 +51,7 @@ final class PageSlugConditionChecker
     public function isPageSlug(string $slug): bool
     {
         try {
-            return $this->pageRepository->existsOneByChannelAndSlug(
+            return $this->pageRepository->existsOneEnabledByChannelAndSlug(
                 $this->channelContext->getChannel(),
                 $this->localeContext->getLocaleCode(),
                 $slug

--- a/src/Validator/Constraints/UniqueSlugByChannel.php
+++ b/src/Validator/Constraints/UniqueSlugByChannel.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Cms Page plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusCmsPagePlugin\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+final class UniqueSlugByChannel extends Constraint
+{
+    public string $message = 'monsieurbiz_cms_page.ui.slug.unique';
+
+    public function validatedBy(): string
+    {
+        return self::class . 'Validator';
+    }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/Constraints/UniqueSlugByChannelValidator.php
+++ b/src/Validator/Constraints/UniqueSlugByChannelValidator.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Cms Page plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusCmsPagePlugin\Validator\Constraints;
+
+use MonsieurBiz\SyliusCmsPagePlugin\Entity\PageInterface;
+use MonsieurBiz\SyliusCmsPagePlugin\Repository\PageRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Webmozart\Assert\Assert;
+
+final class UniqueSlugByChannelValidator extends ConstraintValidator
+{
+    private PageRepositoryInterface $pageRepository;
+
+    public function __construct(PageRepositoryInterface $pageRepository)
+    {
+        $this->pageRepository = $pageRepository;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @param mixed $value
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        /** @var PageInterface $value */
+        Assert::isInstanceOf($value, PageInterface::class);
+        /** @var UniqueSlugByChannel $constraint */
+        Assert::isInstanceOf($constraint, UniqueSlugByChannel::class);
+
+        // Check if the slug is unique for each channel and locale
+        foreach ($value->getTranslations() as $translation) {
+            foreach ($value->getChannels() as $channel) {
+                if ($this->pageRepository->existsOneByChannelAndSlug(
+                        $channel,
+                        $translation->getLocale(),
+                        $translation->getSlug(),
+                        $value->getId() ? [$value] : []
+                    )) {
+                    $this->context->buildViolation($constraint->message, [
+                        '%channel%' => $channel->getCode(),
+                        '%locale%' => $translation->getLocale(),
+                    ])
+                        ->atPath(sprintf('translations[%s].slug', $translation->getLocale()))
+                        ->addViolation()
+                    ;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The PR allows you to create pages with the same slug for different channels and locales.

Example, for my "Fashion" channel: 

![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/7e146f14-1601-4b7e-b404-2bd051cfc8a0)

![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/098fcfd4-0a82-4bf0-9e71-00fbf209461f)

And another page with same slug for my "Test" channel:

![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/b9a3ac8a-b02f-4732-8316-665c12e35d87)

![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/19b7d028-1c66-426b-97d6-544295f6fba5)

If I try to save my second page with the "Fashion" channel:
![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/d4127b57-9b64-4d72-bc27-df6ff328beed)

Or create a new page with same "context":
![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/0aaf62a1-28da-439f-9e69-3c75e30988e4)

Add channel column and filter in page grid:
![image](https://github.com/monsieurbiz/SyliusCmsPagePlugin/assets/465524/bded0d81-b893-4a1e-a60c-b64848f13430)
