### PR TITLE
Update README.md section about Doctrine migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,19 @@ monsieurbiz_cms_page_shop:
 
 ### Migrations
 
-Make a doctrine migration diff : 
+First, please run legacy-versioned migrations by using command :
+
+```bash
+bin/console doctrine:migrations:migrate
+```
+
+After migration, please create a new diff migration :
 
 ```php
 bin/console doctrine:migrations:diff
 ```
 
-Then run it : 
+Then run it (if any) : 
 
 ```php
 bin/console doctrine:migrations:migrate


### PR DESCRIPTION
Clarify installation steps with Doctrine migrations.

There are already Doctrine migrations in SyliusCmsPagePlugin. Generating new one by calling `doctrine:migrations:diff` before calling `doctrine:migrations:migrate` creates duplicate SQL changes. And that effectively breaks `doctrine:migrations:migrate` after as it crash on already existing SQL table.

My proposal is to call `doctrine:migrations:migrate` first, similar as in for example https://github.com/BitBagCommerce/SyliusWishlistPlugin/blob/master/doc/01-installation.md