### PR TITLE
Add permission on routes for sylius plus RBAC

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -3,6 +3,7 @@ monsieurbiz_sylius_cms_page_admin:
     resource: |
         alias: monsieurbiz_cms_page.page
         section: admin
+        permission: true
         templates: "@SyliusAdmin\\Crud"
         except: ['show', 'update']
         redirect: update

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -23,3 +23,8 @@ monsieurbiz_cms_page:
     actions:
       create: 'Create a new page'
       preview: 'Preview'
+sylius_plus:
+  rbac:
+    parent:
+      page: 'Page'
+      pages: 'Pages'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -23,3 +23,8 @@ monsieurbiz_cms_page:
     actions:
       create: 'Créer une nouvelle page'
       preview: 'Prévisualiser'
+sylius_plus:
+  rbac:
+    parent:
+      page: 'Page'
+      pages: 'Pages'


### PR DESCRIPTION
Add permission on routes so the RBAC of Sylius Plus can put be used for the routes of the plugin.

For Sylius Standard it's changing nothing.