### PR TITLE
Remove correctly the locale at the beginning of the route

### DIFF
--- a/src/Routing/RequestContext.php
+++ b/src/Routing/RequestContext.php
@@ -81,7 +81,8 @@ final class RequestContext extends BaseRequestContext
             return $slug;
         }
 
-        return ltrim($slug, sprintf('%s/', $localeCode));
+        // Remove the locale code which is at the beginning of the slug
+        return (string) preg_replace(sprintf('/^%s\//', $localeCode), '', $slug);
     }
 
     /**


### PR DESCRIPTION
Example with a `en` route and `news` slug.

## Before

In URL `en/news`, the `ltrim` keep `ws`

## After

In URL `en/news`, the `preg replace` keep `news`
The regex uses `^` to be sure we only remove the locale at the beginning of the slug. 

See #64 which introduced the issue