### PR TITLE
Fix: avoid server error with a page without slug for wanted locale

### DIFF
--- a/src/Menu/PageUrlProvider.php
+++ b/src/Menu/PageUrlProvider.php
@@ -39,6 +39,7 @@ class PageUrlProvider extends AbstractUrlProvider
     protected function getResults(string $locale, string $search = ''): iterable
     {
         $queryBuilder = $this->pageRepository->createListQueryBuilder($locale)
+            ->andWhere('translation.locale = :localeCode') // Add condition to display only pages with the current locale
             ->andWhere('o.enabled = :enabled')
             ->setParameter('enabled', true)
         ;


### PR DESCRIPTION
Example, we add a new locale (en_US in my case) on the channel and not all pages have been prepared in this locale.

If we try to select a page in this new locale:

**Before**

![image](https://github.com/user-attachments/assets/5015f58a-54f7-4c31-be73-431c3e6980e5)

**After**

![image](https://github.com/user-attachments/assets/f1532f5c-3d62-4c8f-b860-e86145af1e4a)

No impact for my fr_FR:
![image](https://github.com/user-attachments/assets/fbf6667e-dfde-44a5-8ab5-34aa32ec93ec)
