### PR TITLE
FEATURE: add twig component to render link to cms page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This plugins allows you to add manage CMS pages using the Rich Editor and the Media Manager.
 
-If you want to know more about our editor, see the [Rich Editor Plugin](https://github.com/monsieurbiz/SyliusRichEditorPlugin)  
+If you want to know more about our editor, see the [Rich Editor Plugin](https://github.com/monsieurbiz/SyliusRichEditorPlugin)
 If you want to know more about our editor, see the [Media Manager Plugin](https://github.com/monsieurbiz/SyliusMediaManagerPlugin)
 
 ![Example of CMS Page display](screenshots/front-example.png)
@@ -34,9 +34,9 @@ composer config --no-plugins --json extra.symfony.endpoint '["https://api.github
 composer require monsieurbiz/sylius-cms-page-plugin
 ```
 
-If you do not use the recipes : 
+If you do not use the recipes :
 
-Change your `config/bundles.php` file to add the line for the plugin : 
+Change your `config/bundles.php` file to add the line for the plugin :
 
 ```php
 <?php
@@ -54,7 +54,7 @@ imports:
     - { resource: "@MonsieurBizSyliusCmsPagePlugin/Resources/config/config.yaml" }
 ```
 
-Finally import the routes in `config/routes/monsieurbiz_sylius_cms_page_plugin.yaml` : 
+Finally import the routes in `config/routes/monsieurbiz_sylius_cms_page_plugin.yaml` :
 
 ```yaml
 monsieurbiz_cms_page_admin:
@@ -96,7 +96,7 @@ After migration, please create a new diff migration :
 bin/console doctrine:migrations:diff
 ```
 
-Then run it (if any) : 
+Then run it (if any) :
 
 ```php
 bin/console doctrine:migrations:migrate
@@ -114,12 +114,20 @@ bin/console doctrine:migrations:migrate
 
 ## Create custom elements
 
-You can customize and create custom elements in your page.  
+You can customize and create custom elements in your page.
 In order to do that, you can check the [Rich Editor custom element creation](https://github.com/monsieurbiz/SyliusRichEditorPlugin#create-your-own-elements)
+
+## Render a link to a CMS Page
+
+You can use the `PageLink` Twig Component to render a link to any CMS Page in any of your templates.
+
+```html
+{{ component('MonsieurBizSyliusCmsPagePlugin:PageLink', {pageCode: '<code>'}) }}
+```
 
 ## SEO Friendly
 
-You can define for every page the meta title, meta description, meta 
+You can define for every page the meta title, meta description, meta
 keywords and meta image.
 
 ## Troubleshooting
@@ -127,11 +135,11 @@ keywords and meta image.
 ### Locale not found
 
 We've added a new LocaleContext (`LastChanceLocaleContext`) because the locale isn't set in the request when the
-condition on the route is applied.  
+condition on the route is applied.
 Therefore, if you still have an issue with multiple locales in your project, you may need to add another LocaleContext
 in order to find out your locale. The system will take care of the rest.
 
 ## Contributing
 
-You can open an issue or a Pull Request if you want! 😘  
+You can open an issue or a Pull Request if you want! 😘
 Thank you!

--- a/src/DependencyInjection/MonsieurBizSyliusCmsPageExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusCmsPageExtension.php
@@ -40,6 +40,10 @@ final class MonsieurBizSyliusCmsPageExtension extends Extension implements Prepe
                     'template_directory' => '@MonsieurBizSyliusCmsPagePlugin/components/',
                     'name_prefix' => 'CmsPage',
                 ],
+                'MonsieurBiz\SyliusCmsPagePlugin\Twig\Component\\' => [
+                    'template_directory' => '@MonsieurBizSyliusCmsPagePlugin/twig/components/',
+                    'name_prefix' => 'MonsieurBizSyliusCmsPagePlugin',
+                ],
             ],
         ]);
     }

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -125,6 +125,27 @@ class PageRepository extends EntityRepository implements PageRepositoryInterface
         ;
     }
 
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function findOneEnabledAndPublishedByPageCodeAndChannelCode(string $code, string $locale, ChannelInterface $channel, DateTimeInterface $dateTime): ?PageInterface
+    {
+        return $this->createQueryBuilder('p')
+            ->innerJoin('p.translations', 'translation', 'WITH', 'translation.locale = :locale')
+            ->andWhere(':channel MEMBER OF p.channels')
+            ->andWhere('p.enabled = true')
+            ->andWhere('p.code = :code')
+            ->andWhere('p.publishAt IS NULL OR p.publishAt <= :now')
+            ->andWhere('p.unpublishAt IS NULL OR p.unpublishAt >= :now')
+            ->setParameter('now', $dateTime)
+            ->setParameter('channel', $channel)
+            ->setParameter('locale', $locale)
+            ->setParameter('code', $code)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
     private function createQueryBuilderExistOne(ChannelInterface $channel, ?string $locale, string $slug): QueryBuilder
     {
         return $this

--- a/src/Repository/PageRepositoryInterface.php
+++ b/src/Repository/PageRepositoryInterface.php
@@ -34,4 +34,6 @@ interface PageRepositoryInterface extends RepositoryInterface
     public function existsOneEnabledAndPublishedByChannelAndSlug(ChannelInterface $channel, ?string $locale, string $slug, DateTimeInterface $dateTime): bool;
 
     public function findOneEnabledAndPublishedBySlugAndChannelCode(string $slug, string $localeCode, string $channelCode, DateTimeInterface $dateTime): ?PageInterface;
+
+    public function findOneEnabledAndPublishedByPageCodeAndChannelCode(string $code, string $localeCode, ChannelInterface $channel, DateTimeInterface $dateTime): ?PageInterface;
 }

--- a/src/Resources/views/twig/components/PageLink.html.twig
+++ b/src/Resources/views/twig/components/PageLink.html.twig
@@ -1,3 +1,3 @@
 {% if href and page_title %}
-<a href="{{href}}" {{ attributes }}>{{page_title}}</a>
+<a href="{{ href }}" {{ attributes }}>{{ page_title }}</a>
 {% endif %}

--- a/src/Resources/views/twig/components/PageLink.html.twig
+++ b/src/Resources/views/twig/components/PageLink.html.twig
@@ -1,0 +1,2 @@
+
+<a href="{{href}}" {{ attributes }}>{{page_title}}</a>

--- a/src/Resources/views/twig/components/PageLink.html.twig
+++ b/src/Resources/views/twig/components/PageLink.html.twig
@@ -1,2 +1,3 @@
-
+{% if href and page_title %}
 <a href="{{href}}" {{ attributes }}>{{page_title}}</a>
+{% endif %}

--- a/src/Twig/Component/PageLink.php
+++ b/src/Twig/Component/PageLink.php
@@ -18,6 +18,8 @@ final class PageLink
 
     public string $pageCode;
 
+    public int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH;
+
     public function __construct(
         protected LocaleContextInterface $localeContext,
         protected ChannelContextInterface $channelContext,
@@ -37,8 +39,9 @@ final class PageLink
             'monsieurbiz_cms_page_show',
             [
                 '_locale' => $this->localeContext->getLocaleCode(),
-                'slug' => $page->getSlug()
-            ]
+                'slug' => $page->getSlug(),
+            ],
+            $this->referenceType
         );
         return $url;
     }

--- a/src/Twig/Component/PageLink.php
+++ b/src/Twig/Component/PageLink.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MonsieurBiz\SyliusCmsPagePlugin\Twig\Component;
+
+use MonsieurBiz\SyliusCmsPagePlugin\Entity\PageInterface;
+use MonsieurBiz\SyliusCmsPagePlugin\Repository\PageRepositoryInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+#[AsTwigComponent]
+final class PageLink
+{
+    use HookableComponentTrait;
+
+    public string $pageCode;
+
+    public function __construct(
+        protected LocaleContextInterface $localeContext,
+        protected ChannelContextInterface $channelContext,
+        protected PageRepositoryInterface $pageRepository,
+    ) {
+    }
+
+    #[ExposeInTemplate('href')]
+    public function getHref(): string
+    {
+        $page = $this->getPage();
+        return $this->localeContext->getLocaleCode() . '/' . $page->getSlug();
+    }
+
+    #[ExposeInTemplate(name: 'page_title')]
+    public function getPageTitle(): string
+    {
+        return $this->getPage()->getTitle();
+    }
+
+    private function getPage(): PageInterface
+    {
+        $currentLocaleCode = $this->localeContext->getLocaleCode();
+        $channel = $this->channelContext->getChannel();
+        $now = new \DateTime();
+        return $this->pageRepository->findOneEnabledAndPublishedByPageCodeAndChannelCode(
+            $this->pageCode,
+            $currentLocaleCode,
+            $channel,
+            $now
+        );
+    }
+}

--- a/src/Twig/Component/PageLink.php
+++ b/src/Twig/Component/PageLink.php
@@ -3,6 +3,7 @@
 namespace MonsieurBiz\SyliusCmsPagePlugin\Twig\Component;
 
 use MonsieurBiz\SyliusCmsPagePlugin\Entity\PageInterface;
+use MonsieurBiz\SyliusCmsPagePlugin\Entity\PageTranslationInterface;
 use MonsieurBiz\SyliusCmsPagePlugin\Repository\PageRepositoryInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
@@ -17,6 +18,8 @@ final class PageLink
     use HookableComponentTrait;
 
     public string $pageCode;
+
+    public ?string $locale = null;
 
     public int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH;
 
@@ -35,11 +38,15 @@ final class PageLink
         if (!($page instanceof PageInterface)) {
             return '';
         }
+        $translation = $this->getPageTranslation($page);
+        if (null === $translation) {
+            return '';
+        }
         $url = $this->urlGenerator->generate(
             'monsieurbiz_cms_page_show',
             [
-                '_locale' => $this->localeContext->getLocaleCode(),
-                'slug' => $page->getSlug(),
+                '_locale' => $translation->getLocale() ?? $this->resolveLocaleCode(),
+                'slug' => $translation->getSlug(),
             ],
             $this->referenceType
         );
@@ -53,19 +60,50 @@ final class PageLink
         if (!($page instanceof PageInterface)) {
             return '';
         }
-        return $page->getTitle();
+        $translation = $this->getPageTranslation($page);
+
+        return $translation?->getTitle() ?? '';
     }
 
     private function getPage(): ?PageInterface
     {
-        $currentLocaleCode = $this->localeContext->getLocaleCode();
         $channel = $this->channelContext->getChannel();
         $now = new \DateTime();
+
+        $lookupLocaleCode = $channel->getDefaultLocale()?->getCode() ?? $this->resolveLocaleCode();
+
         return $this->pageRepository->findOneEnabledAndPublishedByPageCodeAndChannelCode(
             $this->pageCode,
-            $currentLocaleCode,
+            $lookupLocaleCode,
             $channel,
             $now
         );
+    }
+
+    private function getPageTranslation(PageInterface $page): ?PageTranslationInterface
+    {
+        $translations = $page->getTranslations();
+
+        $preferredTranslation = $translations->get($this->resolveLocaleCode());
+        if ($preferredTranslation instanceof PageTranslationInterface) {
+            return $preferredTranslation;
+        }
+
+        $channelDefaultLocaleCode = $this->channelContext->getChannel()->getDefaultLocale()?->getCode();
+        if (null !== $channelDefaultLocaleCode) {
+            $channelDefaultTranslation = $translations->get($channelDefaultLocaleCode);
+            if ($channelDefaultTranslation instanceof PageTranslationInterface) {
+                return $channelDefaultTranslation;
+            }
+        }
+
+        $fallbackTranslation = $page->getTranslation();
+
+        return $fallbackTranslation instanceof PageTranslationInterface ? $fallbackTranslation : null;
+    }
+
+    private function resolveLocaleCode(): string
+    {
+          return $this->locale ?? $this->localeContext->getLocaleCode();
     }
 }

--- a/src/Twig/Component/PageLink.php
+++ b/src/Twig/Component/PageLink.php
@@ -7,6 +7,7 @@ use MonsieurBiz\SyliusCmsPagePlugin\Repository\PageRepositoryInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
@@ -21,6 +22,7 @@ final class PageLink
         protected LocaleContextInterface $localeContext,
         protected ChannelContextInterface $channelContext,
         protected PageRepositoryInterface $pageRepository,
+        protected UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -28,7 +30,14 @@ final class PageLink
     public function getHref(): string
     {
         $page = $this->getPage();
-        return $this->localeContext->getLocaleCode() . '/' . $page->getSlug();
+        $url = $this->urlGenerator->generate(
+            'monsieurbiz_cms_page_show',
+            [
+                '_locale' => $this->localeContext->getLocaleCode(),
+                'slug' => $page->getSlug()
+            ]
+        );
+        return $url;
     }
 
     #[ExposeInTemplate(name: 'page_title')]

--- a/src/Twig/Component/PageLink.php
+++ b/src/Twig/Component/PageLink.php
@@ -30,6 +30,9 @@ final class PageLink
     public function getHref(): string
     {
         $page = $this->getPage();
+        if (!($page instanceof PageInterface)) {
+            return '';
+        }
         $url = $this->urlGenerator->generate(
             'monsieurbiz_cms_page_show',
             [
@@ -43,10 +46,14 @@ final class PageLink
     #[ExposeInTemplate(name: 'page_title')]
     public function getPageTitle(): string
     {
-        return $this->getPage()->getTitle();
+        $page = $this->getPage();
+        if (!($page instanceof PageInterface)) {
+            return '';
+        }
+        return $page->getTitle();
     }
 
-    private function getPage(): PageInterface
+    private function getPage(): ?PageInterface
     {
         $currentLocaleCode = $this->localeContext->getLocaleCode();
         $channel = $this->channelContext->getChannel();


### PR DESCRIPTION
Add a twig component to render a link to a cms page for a give page code. Now one can add a link to a cms page in any template or hook for example for the header or footer of a sylius shop.